### PR TITLE
Update to return express `app`

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -10,6 +10,7 @@ module.exports = plugin;
 // mount the redirect method
 function plugin(app) {
 	app.redirect = redirect;
+	return app;
 }
 
 // app.redirect(route, target, status)


### PR DESCRIPTION
This allows syntax like the following:

``` js
var express = require('express');
var redirect = require('express-redirect');
var app = module.exports = redirect(express());
```

Which I find quite handy.
